### PR TITLE
fluent validation 

### DIFF
--- a/src/Identity.Application/Commands/CreateNewUserCommandValidation.cs
+++ b/src/Identity.Application/Commands/CreateNewUserCommandValidation.cs
@@ -1,0 +1,32 @@
+﻿using FluentValidation;
+using Identity.Application.Commands;
+using Identity.Application.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Identity.Application.Commands
+{
+    public class CreateNewUserCommandValidation : AbstractValidator<CreateNewUserCommand>
+    {
+        public CreateNewUserCommandValidation()
+        {
+            RuleFor(x => x.Email)
+                .NotEmpty().WithMessage("Введите почту.")
+                .EmailAddress().WithMessage("Почта введена с ошибками.")
+                .MaximumLength(40).WithMessage("Максимальная длина почты 40 символов.");
+
+            RuleFor(x => x.Login)
+                .NotEmpty().WithMessage("Введите логин.")
+                .MinimumLength(6).WithMessage("Минимальная длина логина 6 символов.")
+                .MaximumLength(40).WithMessage("Максимальная длина логина 40 символов.");
+
+            RuleFor(x => x.Password)
+                .NotEmpty().WithMessage("Введите пароль.")
+                .MinimumLength(6).WithMessage("Минимальная длина пароля 6 символов.")
+                .MaximumLength(30).WithMessage("Максимальная длина пароля 30 символов.");
+        }
+    }
+}

--- a/src/Identity.Application/Queries/GetActiveSessionsQuery.cs
+++ b/src/Identity.Application/Queries/GetActiveSessionsQuery.cs
@@ -10,7 +10,6 @@ namespace Identity.Application.Queries
 {
     public class GetActiveSessionsQuery : IRequest<IEnumerable<SessionDto>>
     {
-        public string? CurrentSessionId { get; set; }
         public required string UserId { get; set; }
     }
 }

--- a/src/Identity.WebApi/Controllers/SessionsController.cs
+++ b/src/Identity.WebApi/Controllers/SessionsController.cs
@@ -25,7 +25,6 @@ namespace Identity.WebApi.Controllers
         {
             GetActiveSessionsQuery query = new()
             {
-                CurrentSessionId = authContext.SessionId,
                 UserId = authContext.GetUserIdRequired()
             };
 

--- a/tests/MarketToolsV3.Users.UnitTests/Tests/Applications/Commands/CreateNewUserCommandValidationTests.cs
+++ b/tests/MarketToolsV3.Users.UnitTests/Tests/Applications/Commands/CreateNewUserCommandValidationTests.cs
@@ -1,0 +1,42 @@
+﻿using FluentValidation;
+using Identity.Application.Commands;
+using Identity.Application;
+using Moq;
+using NUnit.Framework;
+
+namespace MarketToolsV3.Users.UnitTests.Tests.Applications.Commands
+{
+    [TestFixture]
+    public class CreateNewUserCommandValidationTests
+    {
+        private Mock<CreateNewUserCommandValidation> _validatorMock;
+
+        [SetUp]
+        public void Setup()
+        {
+            _validatorMock = new Mock<CreateNewUserCommandValidation>() { CallBase = true };
+        }
+
+        [TestCase("ValidLogin", true)]
+        [TestCase("sh", false)]
+        [TestCase("", false)]
+        [TestCase("12345678901234567890123456789012345678901234567890", false)]
+        public void Validate_Login(string login, bool expectedIsValid)
+        {
+            var command = new CreateNewUserCommand { Login = login, Password = "ValidPassword123", Email = "test@example.com" };
+            var result = _validatorMock.Object.Validate(command);
+            Assert.That(result.IsValid, Is.EqualTo(expectedIsValid));
+        }
+
+        [TestCase("StrongPass123", true)]
+        [TestCase("123", false)]
+        [TestCase("", false)]
+        [TestCase("12345678901234567890123456789012345678901234567890", false)]
+        public void Validate_Password(string password, bool expectedIsValid)
+        {
+            var command = new CreateNewUserCommand { Login = "ValidLogin", Password = password, Email = "test@example.com" };
+            var result = _validatorMock.Object.Validate(command);
+            Assert.That(result.IsValid, Is.EqualTo(expectedIsValid));
+        }
+    }
+}

--- a/tests/MarketToolsV3.Users.UnitTests/Tests/Applications/Commands/DeactivateSessionCommandDeepValidateTests.cs
+++ b/tests/MarketToolsV3.Users.UnitTests/Tests/Applications/Commands/DeactivateSessionCommandDeepValidateTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Threading.Tasks;
+using Identity.Application.Commands;
+using Identity.Application.Models;
+using Identity.Application.Services.Abstract;
+using Identity.Application.Utilities.Abstract.Validation;
+using Moq;
+using NUnit.Framework;
+
+namespace Identity.Application.UnitTests.Commands
+{
+    [TestFixture]
+    public class DeactivateSessionCommandDeepValidateTests
+    {
+        private Mock<IStringIdQuickSearchService<SessionDto>> _sessionSearchServiceMock;
+        private DeactivateSessionCommandDeepValidate _validator;
+
+        [SetUp]
+        public void Setup()
+        {
+            _sessionSearchServiceMock = new Mock<IStringIdQuickSearchService<SessionDto>>();
+            _validator = new DeactivateSessionCommandDeepValidate(_sessionSearchServiceMock.Object);
+        }
+
+        [Test]
+        public async Task Handle_InvalidData_ShouldReturnValidationError()
+        {
+            var request = new DeactivateSessionCommand { Id = "invalid-id", UserId = "user123" };
+
+            _sessionSearchServiceMock
+                .Setup(service => service.GetAsync(request.Id, TimeSpan.FromMinutes(15)))
+                .ReturnsAsync(new SessionDto
+                {
+                    Id = "invalid-id",
+                    UserAgent = "TestAgent",
+                    CreateDate = DateTime.UtcNow,
+                    Updated = DateTime.UtcNow,
+                    IsActive = true,
+                    UserId = "differentUser"
+                });
+
+            var result = await _validator.Handle(request);
+
+            Assert.That(result.IsValid, Is.False);
+            Assert.That(result.ErrorMessages, Contains.Item("Нет доступа к сессии."));
+        }
+
+        [Test]
+        public async Task Handle_ValidData_ShouldPassValidation()
+        {
+            var request = new DeactivateSessionCommand { Id = "valid-id", UserId = "user123" };
+
+            _sessionSearchServiceMock
+                .Setup(service => service.GetAsync(request.Id, TimeSpan.FromMinutes(15)))
+                .ReturnsAsync(new SessionDto
+                {
+                    Id = "valid-id",
+                    UserAgent = "TestAgent",
+                    CreateDate = DateTime.UtcNow,
+                    Updated = DateTime.UtcNow,
+                    IsActive = true,
+                    UserId = "user123"
+                });
+
+            var result = await _validator.Handle(request);
+
+            Assert.That(result.IsValid, Is.True);
+            Assert.That(result.ErrorMessages, Is.Empty);
+        }
+    }
+}


### PR DESCRIPTION
Added: fluent validation to dentity.Application.Commands.CreateNewUserCommand
Unit tests for CreateNewUserCommandValidation
Unit tests for Identity.Application.Commands.DeactivateSessionCommandDeepValidate 
Removed CurrentSessionId from Identity.Application.Queries.GetActiveSessionsQuery and it's references